### PR TITLE
Do not rely on acquisition to get portal_membership

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,7 @@ Changelog
 
 1.7-dev - (unreleased)
 ----------------------
+* Use getSite to access portal_membership and don't throw an exception with zope-root users [erral]
 
 1.6 - (2015-01-09)
 ------------------

--- a/edw/userhistory/events.py
+++ b/edw/userhistory/events.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-
+from zope.site.hooks import getSite
 from zope.annotation.interfaces import IAnnotations
 from persistent.list import PersistentList
 
@@ -19,8 +19,8 @@ def get_ip(request):
 def userLoggedIn(user, event):
     userip = get_ip(user.REQUEST)
     logintime = datetime.now()
-
-    member = user.portal_membership.getMemberById(user.getId())
+    site = getSite()
+    member = site.portal_membership.getMemberById(user.getId())
     if member is None:
         return
     anno = IAnnotations(member)


### PR DESCRIPTION
If I login to the site with a user created on Zope Root, the `user.portal_membership` line throws an exception. With this change we use getSite, to get the Plone site and we don't have an error.

This fixes #1 
